### PR TITLE
VersionEye uses flat-squared, satisifies OCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](http://img.shields.io/travis/HippoPHP/Tokenizer.svg?style=flat-square)](https://travis-ci.org/HippoPHP/Tokenizer)
 [![Code Climate](http://img.shields.io/codeclimate/github/HippoPHP/Tokenizer.svg?style=flat-square)](https://codeclimate.com/github/HippoPHP/Tokenizer)
 [![Test Coverage](http://img.shields.io/codeclimate/coverage/github/HippoPHP/Tokenizer.svg?style=flat-square)](https://codeclimate.com/github/HippoPHP/Tokenizer)
-[![Dependencies](http://www.versioneye.com/user/projects/545df0edeb8df2273300003e/badge.svg?style=flat)](http://www.versioneye.com/user/projects/545df0edeb8df2273300003e)
+[![Dependencies](http://www.versioneye.com/user/projects/545df0edeb8df2273300003e/badge.svg?style=flat-square)](http://www.versioneye.com/user/projects/545df0edeb8df2273300003e)
 
 # License
 


### PR DESCRIPTION
Badges are all `flat-square` now.
