### PR TITLE
Closes #31, seekToType allows an array of tokens

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -78,10 +78,14 @@
 
 		/**
 		 * Compares token types.
-		 * @param  string  $tokenType
+		 * @param  mixes  $tokenTypes
 		 * @return boolean
 		 */
-		public function isType($tokenType) {
-			return $this->getType() === $tokenType;
+		public function isType($tokenTypes) {
+			if (is_array($tokenTypes)) {
+				return in_array($this->getType(), $tokenTypes);
+			}
+
+			return $this->getType() === $tokenTypes;
 		}
 	}

--- a/src/TokenListIterator.php
+++ b/src/TokenListIterator.php
@@ -48,15 +48,15 @@
 		}
 
 		/**
-		 * @param string $tokenType
+		 * @param mixed $tokenTypes
 		 * @param int $direction DIR_BACKWARD or DIR_FORWARD
 		 */
-		public function seekToType($tokenType, $direction = self::DIR_FORWARD) {
-			return $this->_safeMove(function() use ($tokenType, $direction) {
+		public function seekToType($tokenTypes, $direction = self::DIR_FORWARD) {
+			return $this->_safeMove(function() use ($tokenTypes, $direction) {
 				$this->_move($direction);
 
-				$this->_moveWithCondition(function() use ($tokenType) {
-					return !$this->current()->isType($tokenType);
+				$this->_moveWithCondition(function() use ($tokenTypes) {
+					return !$this->current()->isType($tokenTypes);
 				}, $direction);
 
 				return $this->current();

--- a/tests/TokenListIteratorTest.php
+++ b/tests/TokenListIteratorTest.php
@@ -77,6 +77,11 @@
 			$this->assertEquals($seekToken, $this->tokenList->seekToType(T_WHITESPACE));
 		}
 
+		public function testSeekToTypeArray() {
+			$seekToken = new Token(T_WHITESPACE, "\t", 2, 1);
+			$this->assertEquals($seekToken, $this->tokenList->seekToType([T_WHITESPACE]));
+		}
+
 		public function testSeekBackwards() {
 			$this->tokenList->seek(2);
 			$actualToken = $this->tokenList->seekToType(T_WHITESPACE, TokenListIterator::DIR_BACKWARD);


### PR DESCRIPTION
I went with option two, as to prevent increasing how many public methods we have.
