### PR TITLE
Removed useless state from Tokenizer

### DIFF
--- a/src/TokenListIterator.php
+++ b/src/TokenListIterator.php
@@ -11,6 +11,13 @@
 		const DIR_BACKWARD = 1;
 
 		/**
+		 * @param Token[] $tokenList
+		 */
+		public function __construct(array $tokens = []) {
+			$this->_tokens = $tokens;
+		}
+
+		/**
 		 * @var int
 		 */
 		private $_position = 0;

--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -8,24 +8,10 @@
 
 	class Tokenizer {
 		/**
-		 * @var \HippoPHP\Tokenizer\TokenListIterator
-		 */
-		private $_tokens;
-
-		/**
-		 * Constructor for the Tokenizer.
-		 * @return \HippoPHP\Tokenizer\Tokenizer
-		 */
-		public function __construct() {
-			$this->_tokens = new TokenListIterator;
-			return $this;
-		}
-
-		/**
 		 * @param string $buffer
-		 * @return array
+		 * @return TokenListIterator
 		 */
-		public function tokenize($buffer) {
+		public static function tokenize($buffer) {
 			if ($buffer === null) {
 				return [];
 			} elseif (!is_string($buffer)) {
@@ -37,7 +23,7 @@
 			$tokenColumn = 1;
 
 			foreach (token_get_all($buffer) as $item) {
-				list($tokenName, $tokenData) = $this->_splitToken($item);
+				list($tokenName, $tokenData) = self::_splitToken($item);
 
 				$tokenList[] = new Token($tokenName, $tokenData, $tokenLine, $tokenColumn);
 
@@ -60,17 +46,7 @@
 				}
 			}
 
-			$this->_tokens->setTokens($tokenList);
-
-			return $this->_tokens;
-		}
-
-		/**
-		 * Return the TokenListIterator
-		 * @return \HippoPHP\Tokenizer\TokenListIterator
-		 */
-		public function getTokenList() {
-			return $this->_tokens;
+			return new TokenListIterator($tokenList);
 		}
 
 		/**
@@ -78,7 +54,7 @@
 		 * @param  mixed $item
 		 * @return array
 		 */
-		private function _splitToken($item) {
+		private static function _splitToken($item) {
 			if (is_array($item)) {
 				$tokenName = $item[0];
 				$tokenData = $item[1];

--- a/tests/TokenizerTest.php
+++ b/tests/TokenizerTest.php
@@ -74,8 +74,4 @@ ETEST
 			$tokenizer = new Tokenizer;
 			$tokenizer->tokenize([]);
 		}
-
-		public function testGetTokens() {
-			$this->assertInstanceOf('\HippoPHP\Tokenizer\TokenListIterator', $this->_tokenizer->getTokenList());
-		}
 	}


### PR DESCRIPTION
1. `Tokenizer::tokenize($buffer)` acts like a static method and returns iterator for tokens.
2. We have `Tokenizer::getTokenList()` that returns the token list that happened to be produced in last call to `::tokenize()`.
3. `Token::getTokenList()` has two issues:
   1. Its name is incorrect, because it refers to result saved from `Tokenizer::getTokenList()`, so it should be at least `::getLastBuiltTokenList()`
   2. Now that it name reflects what it does, don't you think it's just too silly? What is this method good for anyway? Caching? In our case, we already cache it in lazy initializers of HippoPHP's `CheckContext`.

I changed `tokenize()` signature to a static method, and removed obscure state manipulation. I updated `::tokenize()` doc comment to reflect correct return type.
